### PR TITLE
Add differentiable quantum model

### DIFF
--- a/src/data_utils.py
+++ b/src/data_utils.py
@@ -1,12 +1,38 @@
-from torchvision import datasets, transforms
+import types
+import torch
+
+try:
+    from torchvision import datasets as tv_datasets, transforms as tv_transforms
+except Exception:  # pragma: no cover - torchvision may not be installed
+    class DummyCompose:
+        def __init__(self, funcs):
+            self.funcs = funcs
+        def __call__(self, x):
+            for f in self.funcs:
+                x = f(x)
+            return x
+
+    class DummyLambda:
+        def __init__(self, func):
+            self.func = func
+        def __call__(self, x):
+            return self.func(x)
+
+    class DummyToTensor:
+        def __call__(self, x):
+            return torch.tensor(x)
+
+    tv_datasets = types.SimpleNamespace(MNIST=object, CIFAR10=object, CIFAR100=object)
+    tv_transforms = types.SimpleNamespace(Compose=DummyCompose, Lambda=DummyLambda, ToTensor=DummyToTensor)
+
 from config import ENCODING_DIM
 
 
 def get_dataset_class(name: str):
     mapping = {
-        "MNIST": datasets.MNIST,
-        "CIFAR10": datasets.CIFAR10,
-        "CIFAR100": datasets.CIFAR100,
+        "MNIST": tv_datasets.MNIST,
+        "CIFAR10": tv_datasets.CIFAR10,
+        "CIFAR100": tv_datasets.CIFAR100,
     }
     if name not in mapping:
         raise ValueError(f"Unsupported dataset: {name}")
@@ -14,8 +40,8 @@ def get_dataset_class(name: str):
 
 
 def get_transform():
-    return transforms.Compose([
-        transforms.ToTensor(),
-        transforms.Lambda(lambda x: x.view(-1)),
-        transforms.Lambda(lambda x: x[:ENCODING_DIM])
+    return tv_transforms.Compose([
+        tv_transforms.ToTensor(),
+        tv_transforms.Lambda(lambda x: x.view(-1)),
+        tv_transforms.Lambda(lambda x: x[:ENCODING_DIM])
     ])

--- a/src/model.py
+++ b/src/model.py
@@ -1,30 +1,15 @@
 import torch
 import torch.nn as nn
-from qiskit import QuantumCircuit
-from qiskit_aer import AerSimulator
 import numpy as np
-from config import MEASURE_SHOTS, NUM_CLASSES
+from config import NUM_CLASSES
 
 
-def compute_expectations(qc, shots=MEASURE_SHOTS):
-    """Simulate the circuit and return Z-basis expectations for each qubit."""
-    simulator = AerSimulator()
-    result = simulator.run(qc, shots=shots).result()
-    counts = result.get_counts()
-
-    num_qubits = qc.num_qubits
-    expectations = np.zeros(num_qubits)
-    total_shots = sum(counts.values())
-
-    for bitstring, cnt in counts.items():
-        for i, bit in enumerate(reversed(bitstring)):
-            if bit == "0":
-                expectations[i] += cnt
-            else:
-                expectations[i] -= cnt
-
-    expectations /= total_shots
-    return expectations
+def kronecker_product(probs_list):
+    """Compute the Kronecker product of a list of probability vectors."""
+    result = probs_list[0]
+    for p in probs_list[1:]:
+        result = torch.einsum("i,j->ij", result, p).reshape(-1)
+    return result
 
 class QuantumLLPModel(nn.Module):
     def __init__(self, n_qubits):
@@ -32,34 +17,20 @@ class QuantumLLPModel(nn.Module):
         self.n_qubits = n_qubits
         self.params = nn.Parameter(torch.randn(n_qubits, dtype=torch.float32))
 
-    def encode(self, x):
-        qc = QuantumCircuit(self.n_qubits)
-        for i in range(self.n_qubits):
-            qc.ry(float(np.pi * x[i]), i)
-        return qc
-
-    def variational(self, qc, theta):
-        for i in range(self.n_qubits):
-            qc.ry(float(theta[i]), i)
-        return qc
-
-    def measure(self, qc):
-        qc.measure_all()
-        simulator = AerSimulator()
-        result = simulator.run(qc, shots=MEASURE_SHOTS).result()
-        counts = result.get_counts()
-        probs = np.zeros(2**self.n_qubits)
-        for state, count in counts.items():
-            idx = int(state, 2)
-            probs[idx] = count
-        probs /= probs.sum()
-        return torch.tensor(probs[:NUM_CLASSES], dtype=torch.float32)
+    def _state_probs(self, angles):
+        """Return probabilities of measuring each basis state for given angles."""
+        # angles: tensor shape (n_qubits,)
+        p0 = torch.cos(angles / 2) ** 2
+        p1 = torch.sin(angles / 2) ** 2
+        probs_list = [torch.stack([p0[i], p1[i]]) for i in range(self.n_qubits)]
+        probs = kronecker_product(probs_list)
+        return probs
 
     def forward(self, x_batch):
+        x_batch = x_batch.to(self.params.device)
         probs_batch = []
         for x in x_batch:
-            qc = self.encode(x)
-            qc = self.variational(qc, self.params)
-            probs = self.measure(qc)
+            angles = np.pi * x + self.params
+            probs = self._state_probs(angles)[:NUM_CLASSES]
             probs_batch.append(probs)
         return torch.stack(probs_batch)

--- a/tests/test_model_grad.py
+++ b/tests/test_model_grad.py
@@ -1,0 +1,26 @@
+import sys
+import os
+import torch
+
+sys.path.append(os.path.join(os.path.dirname(__file__), '..', 'src'))
+
+from model import QuantumLLPModel
+
+
+def test_single_backward_step():
+    model = QuantumLLPModel(n_qubits=2)
+    optimizer = torch.optim.SGD(model.parameters(), lr=0.1)
+    loss_fn = torch.nn.MSELoss()
+
+    x_batch = torch.rand(4, 2)
+    target = torch.tensor([0.5, 0.5])
+
+    pred = model(x_batch)
+    bag_pred = pred.mean(dim=0)
+    loss = loss_fn(bag_pred, target)
+    loss.backward()
+
+    assert model.params.grad is not None
+    assert torch.any(model.params.grad.abs() > 0)
+
+    optimizer.step()


### PR DESCRIPTION
## Summary
- implement differentiable circuit simulation in `model.py`
- make `data_utils` robust when torchvision isn't present
- add a unit test checking gradients for one optimisation step

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*