### PR TITLE
Fix sampling with nested Subsets

### DIFF
--- a/src/data_utils.py
+++ b/src/data_utils.py
@@ -88,18 +88,25 @@ class FixedBatchSampler(Sampler[List[int]]):
 
 def create_fixed_proportion_batches(dataset, teacher_probs_list, bag_size, num_classes):
     """Return a FixedBatchSampler where each batch matches the given proportions."""
-    if hasattr(dataset, "indices"):
-        indices = list(dataset.indices)
-        base_dataset = dataset.dataset
-    else:
-        indices = list(range(len(dataset)))
-        base_dataset = dataset
+    dataset_indices = list(range(len(dataset)))
+
+    # Walk to the root dataset to access labels
+    base_dataset = dataset
+    while hasattr(base_dataset, "indices"):
+        base_dataset = base_dataset.dataset
     targets = getattr(base_dataset, "targets", getattr(base_dataset, "labels"))
 
     class_to_indices = {i: [] for i in range(num_classes)}
-    for idx in indices:
-        label = int(targets[idx])
+    for idx in dataset_indices:
+        root_idx = idx
+        ds = dataset
+        # Resolve the index through potentially nested Subset objects
+        while hasattr(ds, "indices"):
+            root_idx = ds.indices[root_idx]
+            ds = ds.dataset
+        label = int(targets[root_idx])
         if label < num_classes:
+            # store dataset-relative index
             class_to_indices[label].append(idx)
 
     for idx_list in class_to_indices.values():

--- a/tests/test_sampler.py
+++ b/tests/test_sampler.py
@@ -1,0 +1,38 @@
+import sys
+import os
+import pytest
+
+torch = pytest.importorskip("torch")
+
+sys.path.append(os.path.join(os.path.dirname(__file__), "..", "src"))
+from data_utils import create_fixed_proportion_batches, compute_proportions
+from torch.utils.data import TensorDataset, Subset, random_split
+
+
+def test_sampler_on_nested_subset():
+    # base dataset with alternating labels
+    labels = torch.tensor([0, 1, 0, 1, 0, 1, 0, 1])
+    data = torch.zeros(len(labels), 1)
+    base = TensorDataset(data, labels)
+
+    # first subset keeps all indices but wrapped in Subset
+    first_subset = Subset(base, list(range(len(labels))))
+
+    # create nested subset using random_split
+    sub_a, _ = random_split(first_subset, [4, len(first_subset) - 4],
+                            generator=torch.Generator().manual_seed(0))
+
+    # derive teacher proportions from the selected subset
+    subset_labels = torch.tensor([sub_a[i][1] for i in range(len(sub_a))])
+    teacher = compute_proportions(subset_labels, 2)
+
+    sampler = create_fixed_proportion_batches(sub_a, [teacher], len(sub_a), 2)
+    batches = list(iter(sampler))
+    assert len(batches) == 1
+    batch = batches[0]
+    # indices should be relative to sub_a
+    assert all(0 <= idx < len(sub_a) for idx in batch)
+
+    batch_labels = torch.tensor([sub_a[i][1] for i in batch])
+    props = compute_proportions(batch_labels, 2)
+    assert torch.allclose(props, teacher)


### PR DESCRIPTION
## Summary
- handle nested `Subset` objects in `create_fixed_proportion_batches`
- store dataset-relative indices
- add unit test covering nested subsets

## Testing
- `pytest -q`