### PR TITLE
Fix dataset indices variable

### DIFF
--- a/src/data_utils.py
+++ b/src/data_utils.py
@@ -104,7 +104,7 @@ def create_fixed_proportion_batches(dataset, teacher_probs_list, bag_size, num_c
         targets = base_dataset.labels
 
     class_to_indices = {i: [] for i in range(num_classes)}
-    for idx in dataset_indices:
+    for idx in indices:
         root_idx = idx
         ds = dataset
         # Resolve the index through potentially nested Subset objects


### PR DESCRIPTION
## Summary
- fix undefined `dataset_indices` variable in `create_fixed_proportion_batches`

## Testing
- `pytest -q` *(tests skipped as torch is not installed)*