### PR TITLE
Fix dataset index resolution

### DIFF
--- a/src/data_utils.py
+++ b/src/data_utils.py
@@ -88,16 +88,12 @@ class FixedBatchSampler(Sampler[List[int]]):
 
 def create_fixed_proportion_batches(dataset, teacher_probs_list, bag_size, num_classes):
     """Return a FixedBatchSampler where each batch matches the given proportions."""
-    if hasattr(dataset, "indices"):
-        indices = list(dataset.indices)
-        base_dataset = dataset.dataset
-        # Handle nested Subset objects by unwrapping them and mapping indices
-        while hasattr(base_dataset, "indices"):
-            indices = [base_dataset.indices[i] for i in indices]
-            base_dataset = base_dataset.dataset
-    else:
-        indices = list(range(len(dataset)))
-        base_dataset = dataset
+    dataset_indices = list(range(len(dataset)))
+
+    # Walk to the root dataset to access labels
+    base_dataset = dataset
+    while hasattr(base_dataset, "indices"):
+        base_dataset = base_dataset.dataset
 
     targets = getattr(base_dataset, "targets", None)
     if targets is None:


### PR DESCRIPTION
## Summary
- ensure `create_fixed_proportion_batches` resolves sample labels while keeping batch indices relative to the given dataset

## Testing
- `pytest -q` *(tests skipped as torch isn't installed)*