### PR TITLE
Compute teacher probabilities automatically

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -24,7 +24,3 @@ DEFAULT_EPOCHS = 10
 DEFAULT_LR = 0.01
 RUN_EPOCHS = 5
 RUN_LR = 0.1
-
-# Teacher probabilities for bags
-TEACHER_PROBS_EVEN = [0.1, 0.2, 0.3, 0.4]
-TEACHER_PROBS_ODD = [0.4, 0.3, 0.2, 0.1]

--- a/src/run.py
+++ b/src/run.py
@@ -8,7 +8,7 @@ from data_utils import (
     get_transform,
     filter_indices_by_class,
     compute_proportions,
-    create_fixed_proportion_batches,
+    create_random_bags,
 )
 from config import (
     DATA_ROOT,
@@ -20,8 +20,6 @@ from config import (
     NUM_QUBITS,
     RUN_EPOCHS,
     RUN_LR,
-    TEACHER_PROBS_EVEN,
-    TEACHER_PROBS_ODD,
     NUM_CLASSES,
     DEVICE,
 )
@@ -50,20 +48,11 @@ print(f"Bag size: {BAG_SIZE}")
 print(f"Number of training bags: {num_train_bags}")
 print(f"Number of validation bags: {num_val_bags}")
 
-teacher_probs_train_list = [
-    TEACHER_PROBS_EVEN if i % 2 == 0 else TEACHER_PROBS_ODD
-    for i in range(num_train_bags)
-]
-teacher_probs_val_list = [
-    TEACHER_PROBS_EVEN if i % 2 == 0 else TEACHER_PROBS_ODD
-    for i in range(num_val_bags)
-]
-
-train_sampler = create_fixed_proportion_batches(
-    train_subset, teacher_probs_train_list, BAG_SIZE, NUM_CLASSES
+train_sampler, teacher_probs_train = create_random_bags(
+    train_subset, BAG_SIZE, NUM_CLASSES, shuffle=SHUFFLE_DATA
 )
-val_sampler = create_fixed_proportion_batches(
-    val_subset, teacher_probs_val_list, BAG_SIZE, NUM_CLASSES
+val_sampler, teacher_probs_val = create_random_bags(
+    val_subset, BAG_SIZE, NUM_CLASSES, shuffle=SHUFFLE_DATA
 )
 
 train_loader = DataLoader(train_subset, batch_sampler=train_sampler)
@@ -73,9 +62,7 @@ test_subset = Subset(test_dataset, test_indices)
 test_loader = DataLoader(test_subset, batch_size=BAG_SIZE, shuffle=False)
 print(f"Test subset size: {len(test_subset)}")
 
-# 2. Teacher class distributions (alternating even/odd)
-teacher_probs_train = torch.tensor(teacher_probs_train_list, device=DEVICE)
-teacher_probs_val = torch.tensor(teacher_probs_val_list, device=DEVICE)
+# 2. Teacher class distributions computed from the constructed bags
 
 # 3. Train model
 model = QuantumLLPModel(n_qubits=NUM_QUBITS).to(DEVICE)


### PR DESCRIPTION
## Notes
- Added `create_random_bags` to generate random bags and compute their label proportions.
- Removed predefined teacher probabilities from `config.py`.
- Updated `run.py` to use new function and removed hard-coded proportions.

## Testing
- `pytest -q` *(fails: 3 skipped)*