### PR TITLE
Normalize class probabilities

### DIFF
--- a/src/model.py
+++ b/src/model.py
@@ -34,5 +34,6 @@ class QuantumLLPModel(nn.Module):
                 x = x[: self.n_qubits]
             angles = np.pi * x + self.params
             probs = self._state_probs(angles)[:NUM_CLASSES]
+            probs = probs / probs.sum()
             probs_batch.append(probs)
         return torch.stack(probs_batch)

--- a/tests/test_model_forward.py
+++ b/tests/test_model_forward.py
@@ -1,0 +1,19 @@
+import sys
+import os
+import pytest
+
+torch = pytest.importorskip("torch")
+
+sys.path.append(os.path.join(os.path.dirname(__file__), "..", "src"))
+import config
+from model import QuantumLLPModel
+
+
+def test_forward_outputs_sum_to_one():
+    n_qubits = config.NUM_QUBITS + 1
+    model = QuantumLLPModel(n_qubits=n_qubits)
+    x_batch = torch.rand(2, n_qubits)
+    probs = model(x_batch)
+    assert probs.shape == (2, config.NUM_CLASSES)
+    sums = probs.sum(dim=1)
+    assert torch.allclose(sums, torch.ones_like(sums), atol=1e-6)


### PR DESCRIPTION
## Summary
- keep QuantumLLPModel outputs normalized when truncating amplitudes
- test that forward pass keeps class probabilities summing to one

## Testing
- `pytest -q` *(fails: 5 skipped in 0.01s)*