### PR TITLE
Support tensors on CUDA for circuit creation

### DIFF
--- a/src/quantum_utils.py
+++ b/src/quantum_utils.py
@@ -26,10 +26,17 @@ def data_to_circuit(angles, params=None):
     if QuantumCircuit is None:
         raise ImportError("qiskit is required for circuit construction")
 
-    angles = np.array(angles, dtype=float)
+    if torch.is_tensor(angles):
+        angles = angles.detach().cpu().numpy()
+    else:
+        angles = np.array(angles, dtype=float)
     n_qubits = angles.shape[0]
     if params is not None:
-        angles = angles + np.array(params, dtype=float)
+        if torch.is_tensor(params):
+            params = params.detach().cpu().numpy()
+        else:
+            params = np.array(params, dtype=float)
+        angles = angles + params
     qc = QuantumCircuit(n_qubits)
     for i, theta in enumerate(angles):
         qc.ry(float(theta), i)

--- a/tests/test_quantum_utils.py
+++ b/tests/test_quantum_utils.py
@@ -1,0 +1,19 @@
+import sys
+import os
+import pytest
+
+torch = pytest.importorskip("torch")
+qiskit = pytest.importorskip("qiskit")
+
+sys.path.append(os.path.join(os.path.dirname(__file__), "..", "src"))
+
+from quantum_utils import data_to_circuit
+from qiskit import QuantumCircuit
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+def test_data_to_circuit_cuda_tensor():
+    angles = torch.tensor([0.0, 1.0], device="cuda")
+    circuit = data_to_circuit(angles)
+    assert isinstance(circuit, QuantumCircuit)
+


### PR DESCRIPTION
## Summary
- handle torch tensors directly in `data_to_circuit`
- add a test for CUDA tensor support

## Testing
- `pytest -q`