### PR TITLE
Add parameter shift gradient helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,3 @@ Quantum Learning from Label Proportion
 ```bash
 pytest
 ```
-
-
-このモードは勾配計算ができないため学習用途ではなく、回路の挙動を確
-認したい場合に使用してください。

--- a/README.md
+++ b/README.md
@@ -33,3 +33,22 @@ Quantum Learning from Label Proportion
 ```bash
 pytest
 ```
+
+## 量子回路のシミュレーション
+
+`QuantumLLPModel` はデフォルトでは解析的に測定確率を計算しますが、
+`use_circuit=True` を指定すると、実際に `qiskit` の量子回路を構築して
+シミュレーションすることもできます。
+
+```python
+from model import QuantumLLPModel
+import torch
+
+model = QuantumLLPModel(n_qubits=4, use_circuit=True)
+features = torch.rand(1, 4)
+probs = model(features)
+print(probs)
+```
+
+このモードは勾配計算ができないため学習用途ではなく、回路の挙動を確
+認したい場合に使用してください。

--- a/README.md
+++ b/README.md
@@ -34,21 +34,6 @@ Quantum Learning from Label Proportion
 pytest
 ```
 
-## 量子回路のシミュレーション
-
-`QuantumLLPModel` はデフォルトでは解析的に測定確率を計算しますが、
-`use_circuit=True` を指定すると、実際に `qiskit` の量子回路を構築して
-シミュレーションすることもできます。
-
-```python
-from model import QuantumLLPModel
-import torch
-
-model = QuantumLLPModel(n_qubits=4, use_circuit=True)
-features = torch.rand(1, 4)
-probs = model(features)
-print(probs)
-```
 
 このモードは勾配計算ができないため学習用途ではなく、回路の挙動を確
 認したい場合に使用してください。

--- a/src/quantum_utils.py
+++ b/src/quantum_utils.py
@@ -51,3 +51,44 @@ def circuit_state_probs(circuit):
     state = Statevector.from_instruction(circuit)
     probs = state.probabilities()
     return torch.tensor(probs, dtype=torch.float32)
+
+def parameter_shift_gradients(angles, params, shift=np.pi/2):
+    """Return probabilities and gradients via the parameter-shift rule.
+
+    Parameters
+    ----------
+    angles : Sequence[float] or torch.Tensor
+        Data-encoding rotation angles for each qubit.
+    params : Sequence[float] or torch.Tensor
+        Additional learned rotation angles.
+    shift : float, optional
+        Shift amount for the parameter-shift rule (default: ``π/2``).
+    """
+    if QuantumCircuit is None:
+        raise ImportError("qiskit is required for circuit simulation")
+
+    if torch.is_tensor(angles):
+        angles = angles.detach().cpu().numpy()
+    else:
+        angles = np.array(angles, dtype=float)
+
+    if torch.is_tensor(params):
+        params = params.detach().cpu().numpy()
+    else:
+        params = np.array(params, dtype=float)
+
+    base_circuit = data_to_circuit(angles, params)
+    base_probs = circuit_state_probs(base_circuit)
+
+    grads = []
+    for i in range(len(params)):
+        shift_vec = np.zeros_like(params)
+        shift_vec[i] = shift
+        plus_circ = data_to_circuit(angles, params + shift_vec)
+        minus_circ = data_to_circuit(angles, params - shift_vec)
+        plus_probs = circuit_state_probs(plus_circ)
+        minus_probs = circuit_state_probs(minus_circ)
+        grad = 0.5 * (plus_probs - minus_probs)
+        grads.append(grad)
+    grads = torch.stack(grads, dim=0)
+    return base_probs, grads

--- a/tests/test_param_shift.py
+++ b/tests/test_param_shift.py
@@ -1,0 +1,33 @@
+import sys
+import os
+import pytest
+np = pytest.importorskip("numpy")
+
+# Skip if PyTorch is not installed
+torch = pytest.importorskip("torch")
+
+# Skip if qiskit is not installed
+pytest.importorskip("qiskit")
+
+sys.path.append(os.path.join(os.path.dirname(__file__), "..", "src"))
+from quantum_utils import parameter_shift_gradients
+from model import QuantumLLPModel
+
+
+def test_parameter_shift_matches_autograd():
+    n_qubits = 2
+    model = QuantumLLPModel(n_qubits=n_qubits)
+    x = torch.rand(n_qubits)
+    params = torch.randn(n_qubits, requires_grad=True)
+
+    probs = model._state_probs(np.pi * x + params)
+
+    def f(p):
+        return model._state_probs(np.pi * x + p)
+
+    jac = torch.autograd.functional.jacobian(f, params)
+
+    ps_probs, grads = parameter_shift_gradients(np.pi * x, params.detach())
+
+    assert torch.allclose(probs, ps_probs, atol=1e-6)
+    assert torch.allclose(grads.t(), jac, atol=1e-5)


### PR DESCRIPTION
## Summary
- implement `parameter_shift_gradients` helper in `quantum_utils.py`
- add a test skeleton for parameter-shift gradients (skipped if qiskit unavailable)

## Testing
- `pytest -q`