### PR TITLE
Improve DataLoader performance

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,8 +15,10 @@ Quantum Learning from Label Proportion
    ```bash
    python src/run.py
    ```
-   学習が完了すると `trained_quantum_llp.pt` が作成されます。
-   CUDA が利用可能な環境では自動的に GPU を使用して計算します。
+  学習が完了すると `trained_quantum_llp.pt` が作成されます。
+  CUDA が利用可能な環境では自動的に GPU を使用して計算します。
+  データ読み込みのワーカー数は `config.NUM_WORKERS` で調整できます。
+  DINO 特徴量を事前計算する場合は `config.PRELOAD_DATASET=True` を設定します。
 
 ## Docker での実行
 1. Docker イメージをビルドします。

--- a/src/config.py
+++ b/src/config.py
@@ -1,5 +1,6 @@
 # Configuration for Q-LLP project
 import torch
+import os
 
 # Dataset settings
 DATA_ROOT = "./data"
@@ -11,6 +12,14 @@ USE_DINO = True  # whether to encode images using DINOv2 features
 SHUFFLE_DATA = True
 DATASET = "CIFAR10"  # Options: MNIST, CIFAR10, CIFAR100
 VAL_SPLIT = 0.2
+
+# DataLoader settings
+NUM_WORKERS = min(4, os.cpu_count() or 1)
+PIN_MEMORY = torch.cuda.is_available()
+
+# Dataset preload
+PRELOAD_DATASET = True
+PRELOAD_BATCH_SIZE = 128
 
 # Device configuration
 DEVICE = torch.device("cuda" if torch.cuda.is_available() else "cpu")

--- a/src/run.py
+++ b/src/run.py
@@ -8,6 +8,7 @@ from data_utils import (
     get_transform,
     filter_indices_by_class,
     compute_proportions,
+    preload_dataset,
 )
 from config import (
     DATA_ROOT,
@@ -22,6 +23,10 @@ from config import (
     NUM_CLASSES,
     DEVICE,
     USE_DINO,
+    NUM_WORKERS,
+    PIN_MEMORY,
+    PRELOAD_DATASET,
+    PRELOAD_BATCH_SIZE,
 )
 
 # Print basic information
@@ -37,6 +42,9 @@ test_dataset = DatasetClass(root=DATA_ROOT, train=False, download=True, transfor
 
 train_indices = filter_indices_by_class(train_full, NUM_CLASSES)[:SUBSET_SIZE]
 subset = Subset(train_full, train_indices)
+if PRELOAD_DATASET:
+    print("Preloading training subset features...")
+    subset = preload_dataset(subset, batch_size=PRELOAD_BATCH_SIZE)
 val_size = int(len(subset) * VAL_SPLIT)
 train_size = len(subset) - val_size
 train_subset, val_subset = random_split(subset, [train_size, val_size])
@@ -51,7 +59,17 @@ print(f"Number of validation bags: {num_val_bags}")
 
 test_indices = filter_indices_by_class(test_dataset, NUM_CLASSES)
 test_subset = Subset(test_dataset, test_indices)
-test_loader = DataLoader(test_subset, batch_size=BAG_SIZE, shuffle=False)
+if PRELOAD_DATASET:
+    print("Preloading test subset features...")
+    test_subset = preload_dataset(test_subset, batch_size=PRELOAD_BATCH_SIZE)
+test_loader = DataLoader(
+    test_subset,
+    batch_size=BAG_SIZE,
+    shuffle=False,
+    num_workers=NUM_WORKERS,
+    pin_memory=PIN_MEMORY,
+    persistent_workers=NUM_WORKERS > 0,
+)
 print(f"Test subset size: {len(test_subset)}")
 
 # 2. Teacher class distributions are computed inside the trainer
@@ -78,7 +96,7 @@ print("Model saved to trained_quantum_llp.pt")
 model.eval()
 with torch.no_grad():
     for i, (x_batch, y_batch) in enumerate(test_loader):
-        x_batch = x_batch.to(DEVICE)
+        x_batch = x_batch.to(DEVICE, non_blocking=PIN_MEMORY)
         pred_probs = model(x_batch)
         bag_pred = pred_probs.mean(dim=0)
         bag_true = compute_proportions(y_batch, NUM_CLASSES)


### PR DESCRIPTION
## Summary
- add NUM_WORKERS and PIN_MEMORY settings to config
- update trainer to use multi-worker DataLoader and non-blocking transfers
- apply the same options in run.py
- mention NUM_WORKERS in README
- preload dataset features for faster epochs

## Testing
- `pytest -q`
