### PR TITLE
Enable GPU verification via nvidia-smi

### DIFF
--- a/Dockerfile/Dockerfile
+++ b/Dockerfile/Dockerfile
@@ -1,4 +1,19 @@
-FROM python:3.11-slim
+# Base image with CUDA and `nvidia-smi` so GPU usage can be verified.
+FROM nvidia/cuda:12.1.1-cudnn8-runtime-ubuntu22.04
+
+
+# Install Python and pip. Create short aliases so `python`/`pip` work.
+RUN apt-get update \ 
+    && apt-get install -y python3 python3-pip \ 
+    && ln -s /usr/bin/python3 /usr/local/bin/python \ 
+    && ln -s /usr/bin/pip3 /usr/local/bin/pip \ 
+    && rm -rf /var/lib/apt/lists/*
+
 WORKDIR /app
-RUN pip install --no-cache-dir torch torchvision qiskit pytest qiskit_aer
+
+# Install PyTorch with CUDA support and the remaining dependencies.
+RUN pip install --no-cache-dir torch torchvision --index-url https://download.pytorch.org/whl/cu121 \ 
+    && pip install --no-cache-dir qiskit qiskit_aer pytest
+
+# Default command runs the training script.
 CMD ["python", "src/run.py"]


### PR DESCRIPTION
## Summary
- switch Docker base image to `nvidia/cuda` so `nvidia-smi` is available
- install Python and PyTorch with CUDA support

## Testing
- `pytest -q` *(fails: 7 skipped)*