### PR TITLE
Fix DataLoader cleanup to avoid semaphore warnings

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,9 +18,11 @@ Quantum Learning from Label Proportion
   学習が完了すると `trained_quantum_llp.pt` が作成されます。
   CUDA が利用可能な環境では自動的に GPU を使用して計算します。
   データ読み込みのワーカー数は `config.NUM_WORKERS` で調整できます。
-  GPU 利用時にワーカーを有効にするため、スクリプト冒頭で
-  `torch.multiprocessing.set_start_method("spawn")` を呼び出しています。
-  特徴量を事前計算してメモリに展開するには `config.PRELOAD_DATASET` を `True` に設定します。
+    GPU 利用時にワーカーを有効にするため、スクリプト冒頭で
+    `torch.multiprocessing.set_start_method("spawn")` を呼び出しています。
+    `DataLoader` のワーカーが正しく終了しない場合に備え、
+    スクリプトでは使用後に明示的にワーカーを停止しています。
+    特徴量を事前計算してメモリに展開するには `config.PRELOAD_DATASET` を `True` に設定します。
 
 ## Docker での実行
 1. Docker イメージをビルドします。

--- a/src/run.py
+++ b/src/run.py
@@ -142,5 +142,9 @@ def main() -> None:
     metrics = evaluate_model(model, test_loader, NUM_CLASSES, device=DEVICE)
     print("Evaluation on test set:", metrics)
 
+    # Explicitly shut down worker processes to avoid leaked semaphores
+    if hasattr(test_loader, "_shutdown_workers"):
+        test_loader._shutdown_workers()
+
 if __name__ == "__main__":
     main()

--- a/src/trainer.py
+++ b/src/trainer.py
@@ -101,6 +101,12 @@ def train_model(
             f"Epoch {epoch+1}/{epochs}, Train Loss: {avg_loss:.4f}, Val Loss: {avg_val_loss:.4f}"
         )
 
+        # Explicitly shut down worker processes to avoid leaked semaphores
+        if hasattr(train_loader, "_shutdown_workers"):
+            train_loader._shutdown_workers()
+        if hasattr(val_loader, "_shutdown_workers"):
+            val_loader._shutdown_workers()
+
 
 def evaluate_model(model, data_loader, num_classes, device=DEVICE):
     """Return average MSE, cross entropy and accuracy."""
@@ -156,4 +162,9 @@ def evaluate_model(model, data_loader, num_classes, device=DEVICE):
     avg_mse = mse_total / len(batches)
     avg_ce = ce_total / len(batches)
     accuracy = total_correct / total_samples if total_samples > 0 else 0.0
+
+    # Explicitly shut down worker processes to avoid leaked semaphores
+    if hasattr(data_loader, "_shutdown_workers"):
+        data_loader._shutdown_workers()
+
     return {"mse": avg_mse, "cross_entropy": avg_ce, "accuracy": accuracy}


### PR DESCRIPTION
## Summary
- gracefully shut down DataLoader worker processes
- update README with note about worker shutdown

## Testing
- `pytest -q`