### PR TITLE
Add circuit export utility

### DIFF
--- a/Dockerfile/Dockerfile
+++ b/Dockerfile/Dockerfile
@@ -6,6 +6,8 @@ WORKDIR /app
 # PyTorch is preinstalled in the base image. Install the remaining
 # dependencies required for this project.
 RUN pip install --no-cache-dir \
+    torchvision \
+    matplotlib \
     qiskit==2.0.2 \
     qiskit_aer==0.17.0 \
     pytest==8.3.5

--- a/README.md
+++ b/README.md
@@ -8,9 +8,11 @@ Quantum Learning from Label Proportion
    source venv/bin/activate
    ```
 2. 依存パッケージをインストールします。
+   `matplotlib` を含めると回路図の保存が可能になります。
    ```bash
-   pip install torch torchvision qiskit pytest
+   pip install torch torchvision qiskit matplotlib pytest
    ```
+   `qiskit` のインポートに失敗する場合は、後述の Docker 環境の利用も検討してください。
 3. 学習を実行します。
    ```bash
    python src/run.py
@@ -27,6 +29,7 @@ Quantum Learning from Label Proportion
    ```bash
    docker build -t q-llp -f Dockerfile/Dockerfile .
    ```
+   ここで作成されるイメージには `qiskit`、`torchvision`、`matplotlib` など必要な依存関係がすべて含まれています。
 2. 作業ディレクトリをコンテナにマウントして学習を実行します。GPU を利用する場合は `--gpus all` を指定します。
    ```bash
    sudo docker run --rm --gpus all -v $(pwd):/app -w /app q-llp python src/run.py

--- a/README.md
+++ b/README.md
@@ -37,3 +37,16 @@ Quantum Learning from Label Proportion
 ```bash
 pytest
 ```
+
+## 回路図の保存
+`scripts/save_circuit_png.py` を実行することで、サンプル回路を描画した
+PNG ファイルを保存できます。
+```bash
+python scripts/save_circuit_png.py circuit.png
+```
+
+学習後のモデルから回路図を保存するには `src/run.py` を
+`--save-circuit` オプション付きで実行します。
+```bash
+python src/run.py --save-circuit trained_circuit.png
+```

--- a/scripts/save_circuit_png.py
+++ b/scripts/save_circuit_png.py
@@ -1,0 +1,21 @@
+import argparse
+import numpy as np
+
+from quantum_utils import data_to_circuit, save_circuit_png
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Save a quantum circuit diagram")
+    parser.add_argument("outfile", help="Destination PNG file")
+    args = parser.parse_args()
+
+    # Example circuit: two qubits with simple rotations
+    angles = np.array([0.0, np.pi / 4])
+    params = np.array([np.pi / 3, np.pi / 6])
+    circuit = data_to_circuit(angles, params)
+
+    save_circuit_png(circuit, args.outfile)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/save_trained_circuit.py
+++ b/scripts/save_trained_circuit.py
@@ -1,0 +1,36 @@
+import argparse
+import torch
+
+from model import QuantumLLPModel
+from quantum_utils import save_model_circuit
+from config import NUM_QUBITS, NUM_LAYERS
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Load a trained model and save its circuit diagram"
+    )
+    parser.add_argument(
+        "model_file",
+        help="Path to the saved model state (.pt file)"
+    )
+    parser.add_argument(
+        "outfile",
+        help="Destination PNG file for the circuit diagram"
+    )
+    args = parser.parse_args()
+
+    model = QuantumLLPModel(
+        n_qubits=NUM_QUBITS,
+        num_layers=NUM_LAYERS,
+        entangling=NUM_LAYERS > 1,
+    )
+    state_dict = torch.load(args.model_file, map_location="cpu")
+    model.load_state_dict(state_dict)
+
+    save_model_circuit(model, args.outfile)
+    print(f"Circuit diagram saved to {args.outfile}")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/run.py
+++ b/src/run.py
@@ -1,12 +1,21 @@
 import torch
 from torch.utils.data import DataLoader, Subset, random_split
 import torch.multiprocessing as mp
+import argparse
 
 
 def main() -> None:
     """Entry point for training and evaluation."""
     # Ensure CUDA works with DataLoader worker processes
     mp.set_start_method("spawn", force=True)
+
+    parser = argparse.ArgumentParser(description="Train Quantum LLP model")
+    parser.add_argument(
+        "--save-circuit",
+        metavar="PNG",
+        help="Save trained circuit diagram to the given file",
+    )
+    args = parser.parse_args()
 
     from model import QuantumLLPModel
     from trainer import train_model, evaluate_model
@@ -116,6 +125,14 @@ def main() -> None:
 # 4. Save model
     torch.save(model.state_dict(), "trained_quantum_llp.pt")
     print("Model saved to trained_quantum_llp.pt")
+
+    if args.save_circuit:
+        try:
+            from quantum_utils import save_model_circuit
+            save_model_circuit(model, args.save_circuit)
+            print(f"Circuit diagram saved to {args.save_circuit}")
+        except Exception as exc:  # pragma: no cover - optional feature
+            print(f"Could not save circuit diagram: {exc}")
 
 # 5. Inference on a few test batches and evaluation
     model.eval()

--- a/tests/test_quantum_utils.py
+++ b/tests/test_quantum_utils.py
@@ -4,11 +4,15 @@ import pytest
 
 torch = pytest.importorskip("torch")
 qiskit = pytest.importorskip("qiskit")
+pytest.importorskip("matplotlib")
 
 sys.path.append(os.path.join(os.path.dirname(__file__), "..", "src"))
 
 from quantum_utils import data_to_circuit
 from qiskit import QuantumCircuit
+
+from quantum_utils import save_circuit_png, save_model_circuit
+from model import QuantumLLPModel
 
 
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
@@ -17,3 +21,17 @@ def test_data_to_circuit_cuda_tensor():
     circuit = data_to_circuit(angles)
     assert isinstance(circuit, QuantumCircuit)
 
+
+def test_save_circuit_png(tmp_path):
+    angles = [0.0, 0.5]
+    circuit = data_to_circuit(angles)
+    out_file = tmp_path / "circuit.png"
+    save_circuit_png(circuit, out_file)
+    assert out_file.exists()
+
+
+def test_save_model_circuit(tmp_path):
+    model = QuantumLLPModel(n_qubits=2)
+    out_file = tmp_path / "model_circuit.png"
+    save_model_circuit(model, out_file)
+    assert out_file.exists()


### PR DESCRIPTION
## Summary
- add optional CLI argument to save model circuit after training
- add `save_model_circuit` helper
- avoid network dependencies in tests
- provide fallback when `tqdm` is missing
- document circuit saving in README

## Testing
- `pytest -q`
