### PR TITLE
Fix gate imports for Qiskit 2.0

### DIFF
--- a/src/quantum_utils.py
+++ b/src/quantum_utils.py
@@ -11,9 +11,15 @@ try:
         CRYGate,
         CU3Gate,
         RXXGate,
-        IsingXYGate,
         MultiRZGate,
     )
+    try:  # Qiskit <2.0 uses IsingXYGate, >=2.0 renamed it
+        from qiskit.circuit.library import IsingXYGate
+    except Exception:  # pragma: no cover - handle version differences
+        try:
+            from qiskit.circuit.library import XXPlusYYGate as IsingXYGate
+        except Exception:
+            from qiskit.circuit.library import XYGate as IsingXYGate
 except Exception:  # pragma: no cover - qiskit may not be installed
     QuantumCircuit = None
     Statevector = None
@@ -248,6 +254,6 @@ def adaptive_entangling_circuit(
 
     # Stage 5: global multi-qubit rotation
     global_angle = np.pi * delta * x[min(features_per_layer - 1, len(x) - 1)]
-    qc.append(MultiRZGate(global_angle, num_qubits), list(range(n_qubits)))
+    qc.append(MultiRZGate(global_angle, n_qubits), list(range(n_qubits)))
 
     return qc

--- a/src/quantum_utils.py
+++ b/src/quantum_utils.py
@@ -3,27 +3,22 @@ import torch
 
 import config
 
-try:
-    from qiskit import QuantumCircuit
-    from qiskit.quantum_info import Statevector
-    from qiskit.circuit.library import (
-        CRXGate,
-        CRYGate,
-        CU3Gate,
-        RXXGate,
-        MultiRZGate,
-    )
-    try:  # Qiskit <2.0 uses IsingXYGate, >=2.0 renamed it
-        from qiskit.circuit.library import IsingXYGate
-    except Exception:  # pragma: no cover - handle version differences
-        try:
-            from qiskit.circuit.library import XXPlusYYGate as IsingXYGate
-        except Exception:
-            from qiskit.circuit.library import XYGate as IsingXYGate
-except Exception:  # pragma: no cover - qiskit may not be installed
-    QuantumCircuit = None
-    Statevector = None
-
+from qiskit import QuantumCircuit
+from qiskit.quantum_info import Statevector
+from qiskit.circuit.library import (
+    CRXGate,
+    CRYGate,
+    CU3Gate,
+    RXXGate,
+    MultiRZGate,
+)
+try:  # Qiskit <2.0 uses IsingXYGate, >=2.0 renamed it
+    from qiskit.circuit.library import IsingXYGate
+except Exception:  # pragma: no cover - handle version differences
+    try:
+        from qiskit.circuit.library import XXPlusYYGate as IsingXYGate
+    except Exception:
+        from qiskit.circuit.library import XYGate as IsingXYGate
 
 def data_to_circuit(angles, params=None, entangling=False):
     """Return a QuantumCircuit encoding ``angles`` via Y rotations.


### PR DESCRIPTION
## Summary
- handle renamed `IsingXYGate` in Qiskit >=2.0 by checking for `XXPlusYYGate` or `XYGate`
- use the correct variable when constructing the global `MultiRZGate`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_683d6e8643048330a01718f402df811e