### PR TITLE
Fix numpy compatibility issues

### DIFF
--- a/src/model.py
+++ b/src/model.py
@@ -11,10 +11,10 @@ from quantum_utils import (
 
 
 def kronecker_product(probs_list):
-    """Compute the Kronecker product of a list of probability vectors."""
+    """Compute the Kronecker product with qubit 0 as the least significant."""
     result = probs_list[0]
     for p in probs_list[1:]:
-        result = torch.einsum("i,j->ij", result, p).reshape(-1)
+        result = torch.einsum("i,j->ij", p, result).reshape(-1)
     return result
 
 

--- a/src/quantum_utils.py
+++ b/src/quantum_utils.py
@@ -53,15 +53,14 @@ def data_to_circuit(angles, params=None, entangling=False):
     """
 
     if torch.is_tensor(angles):
-        angles = angles.detach().cpu().numpy()
-    else:
-        angles = np.array(angles, dtype=float)
+        angles = angles.detach().cpu().tolist()
+    angles = np.array(angles, dtype=float)
     n_qubits = angles.shape[0]
 
     # Backwards compatible path: single parameter vector without entanglement
     if params is not None and not entangling and np.ndim(params) == 1:
         if torch.is_tensor(params):
-            params = params.detach().cpu().numpy()
+            params = params.detach().cpu().tolist()
         angles = angles + np.array(params, dtype=float)
         qc = QuantumCircuit(n_qubits)
         for i, theta in enumerate(angles):
@@ -74,12 +73,12 @@ def data_to_circuit(angles, params=None, entangling=False):
 
     if params is not None:
         if torch.is_tensor(params):
-            params = params.detach().cpu().numpy()
+            params = params.detach().cpu().tolist()
         params = np.array(params, dtype=float)
         params = np.atleast_2d(params)
         for layer in params:
             for q, theta in enumerate(layer):
-                qc.rz(float(theta), q)
+                qc.ry(float(theta), q)
             if entangling and n_qubits > 1:
                 for q in range(n_qubits - 1):
                     qc.cx(q, q + 1)
@@ -116,14 +115,12 @@ def parameter_shift_gradients(angles, params, shift=np.pi / 2, entangling=False)
 
 
     if torch.is_tensor(angles):
-        angles = angles.detach().cpu().numpy()
-    else:
-        angles = np.array(angles, dtype=float)
+        angles = angles.detach().cpu().tolist()
+    angles = np.array(angles, dtype=float)
 
     if torch.is_tensor(params):
-        params = params.detach().cpu().numpy()
-    else:
-        params = np.array(params, dtype=float)
+        params = params.detach().cpu().tolist()
+    params = np.array(params, dtype=float)
 
     # Backwards compatible path: single layer without entanglement
     if params.ndim == 1 and not entangling:
@@ -202,7 +199,7 @@ def adaptive_entangling_circuit(
 
 
     if torch.is_tensor(x):
-        x = x.detach().cpu().numpy()
+        x = x.detach().cpu().tolist()
     x = np.array(x, dtype=float)
 
     if len(x) < features_per_layer:
@@ -250,6 +247,6 @@ def adaptive_entangling_circuit(
 
     # Stage 5: global multi-qubit rotation
     global_angle = np.pi * delta * x[min(features_per_layer - 1, len(x) - 1)]
-    qc.append(multi_rz(global_angle, n_qubits), list(range(n_qubits)))
+    multi_rz(qc, list(range(n_qubits)), global_angle)
 
     return qc

--- a/src/run.py
+++ b/src/run.py
@@ -127,8 +127,12 @@ def main() -> None:
             pred_probs = model(x_batch)
             bag_pred = pred_probs.mean(dim=0)
             bag_true = compute_proportions(y_batch, NUM_CLASSES)
-            print(f"Test batch {i+1} predicted class proportions: {bag_pred.cpu().numpy()}")
-            print(f"Test batch {i+1} true class proportions: {bag_true.numpy()}")
+            print(
+                f"Test batch {i+1} predicted class proportions: {bag_pred.cpu().tolist()}"
+            )
+            print(
+                f"Test batch {i+1} true class proportions: {bag_true.tolist()}"
+            )
             if i >= 1:  # limit output for brevity
                 break
 


### PR DESCRIPTION
## Summary
- avoid tensor.numpy() to prevent import errors with NumPy 2.x
- swap Kronecker product order to match Qiskit state indexing
- use `RY` gates for parameterized layers and adjust adaptive circuit
- handle printing without numpy in run script

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_683fd98e98e08330abfa5cfa403b8486