### PR TITLE
Return full output distribution

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,3 +62,6 @@ simulation is still enabled automatically when entangling layers or
 multiple parameterized layers are used. When only a single non-entangling
 layer is present, class probabilities for the output qubits are computed
 analytically for improved performance.
+When using dedicated output qubits, the training labels are converted
+to probability vectors of length `2 ** NUM_OUTPUT_QUBITS` so that the
+loss computation matches the model output.

--- a/src/model.py
+++ b/src/model.py
@@ -116,7 +116,7 @@ class QuantumLLPModel(nn.Module):
         p0 = p0.unsqueeze(0).expand(n, -1)
         p1 = p1.unsqueeze(0).expand(n, -1)
         probs = torch.where(patterns == 1, p1, p0).prod(dim=1)
-        return probs[:NUM_CLASSES]
+        return probs
 
     def _state_probs(self, angles):
         """Return probabilities of measuring each basis state for given angles."""
@@ -131,19 +131,19 @@ class QuantumLLPModel(nn.Module):
         return probs.to(angles.device)
 
     def _output_probs(self, full_probs):
-        """Return class probabilities from full basis state probabilities."""
+        """Return probabilities for the dedicated output qubits."""
         if self.n_output_qubits == 0:
-            return full_probs[:NUM_CLASSES]
+            return full_probs
         # When using ``CircuitProbFunction`` with ``qargs`` specified, the
         # returned probabilities already correspond to the output qubits only.
         if full_probs.numel() == 2 ** self.n_output_qubits:
-            return full_probs[:NUM_CLASSES]
+            return full_probs
 
         probs = full_probs.view(
             2 ** self.n_feature_qubits, 2 ** self.n_output_qubits
         )
         out_probs = probs.sum(dim=0)
-        return out_probs[:NUM_CLASSES]
+        return out_probs
 
     def forward(self, x_batch):
         x_batch = x_batch.to(self.params.device)

--- a/src/run.py
+++ b/src/run.py
@@ -126,13 +126,15 @@ def main() -> None:
             x_batch = x_batch.to(DEVICE, non_blocking=PIN_MEMORY)
             pred_probs = model(x_batch)
             bag_pred = pred_probs.mean(dim=0)
-            bag_true = compute_proportions(y_batch, NUM_CLASSES)
+            out_dim = 2 ** NUM_OUTPUT_QUBITS if NUM_OUTPUT_QUBITS > 0 else NUM_CLASSES
+            bag_true = compute_proportions(y_batch, out_dim)
             print(f"Test batch {i+1} predicted class proportions: {bag_pred.cpu().numpy()}")
             print(f"Test batch {i+1} true class proportions: {bag_true.numpy()}")
             if i >= 1:  # limit output for brevity
                 break
 
-    metrics = evaluate_model(model, test_loader, NUM_CLASSES, device=DEVICE)
+    out_dim = 2 ** NUM_OUTPUT_QUBITS if NUM_OUTPUT_QUBITS > 0 else NUM_CLASSES
+    metrics = evaluate_model(model, test_loader, out_dim, device=DEVICE)
     print("Evaluation on test set:", metrics)
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- expose complete output qubit probabilities
- ensure label proportions expand to `2**NUM_OUTPUT_QUBITS`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_6841392c08688330946ff80f52711482