### PR TITLE
Fix quantum utilities to work without numpy bridge

### DIFF
--- a/src/run.py
+++ b/src/run.py
@@ -127,8 +127,12 @@ def main() -> None:
             pred_probs = model(x_batch)
             bag_pred = pred_probs.mean(dim=0)
             bag_true = compute_proportions(y_batch, NUM_CLASSES)
-            print(f"Test batch {i+1} predicted class proportions: {bag_pred.cpu().numpy()}")
-            print(f"Test batch {i+1} true class proportions: {bag_true.numpy()}")
+            print(
+                f"Test batch {i+1} predicted class proportions: {bag_pred.cpu().tolist()}"
+            )
+            print(
+                f"Test batch {i+1} true class proportions: {bag_true.cpu().tolist()}"
+            )
             if i >= 1:  # limit output for brevity
                 break
 


### PR DESCRIPTION
## Summary
- avoid Torch numpy conversion in quantum_utils and run.py
- apply parameter-shift using `RY` layers so gradients propagate
- fix qubit ordering when reading probabilities from qiskit
- update adaptive entangling circuit global rotation call

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68415b5c6cd88330b219aa0b03be94a9