### PR TITLE
Avoid initial rotations on output qubits

### DIFF
--- a/src/model.py
+++ b/src/model.py
@@ -29,7 +29,12 @@ class CircuitProbFunction(torch.autograd.Function):
         ctx.shots = shots
         ctx.save_for_backward(params, x)
 
-        circuit = data_to_circuit(np.pi * x.cpu(), params.cpu(), entangling=entangling)
+        circuit = data_to_circuit(
+            np.pi * x.cpu(),
+            params.cpu(),
+            entangling=entangling,
+            n_output_qubits=len(ctx.qargs) if ctx.qargs else 0,
+        )
         probs = circuit_state_probs(circuit, qargs=qargs, shots=shots)
         return probs.to(params.device)
 
@@ -43,6 +48,7 @@ class CircuitProbFunction(torch.autograd.Function):
             entangling=ctx.entangling,
             qargs=ctx.qargs,
             shots=ctx.shots,
+            n_output_qubits=len(ctx.qargs) if ctx.qargs else 0,
         )
         grads = grads.to(grad_output.device)
         grad_params = torch.einsum("p,lqp->lq", grad_output, grads)

--- a/src/plot_circuit.py
+++ b/src/plot_circuit.py
@@ -22,7 +22,12 @@ def main(model_path: str, output: str | None) -> None:
     model = load_model(model_path)
 
     angles = torch.zeros(NUM_QUBITS + NUM_OUTPUT_QUBITS)
-    circuit = data_to_circuit(angles, model.params.detach(), entangling=model.entangling)
+    circuit = data_to_circuit(
+        angles,
+        model.params.detach(),
+        entangling=model.entangling,
+        n_output_qubits=NUM_OUTPUT_QUBITS,
+    )
 
     if output:
         circuit.draw(output="mpl", filename=output)


### PR DESCRIPTION
## Summary
- skip Ry and the first Rz gate for dedicated output qubits
- add `n_output_qubits` argument to `data_to_circuit` and `parameter_shift_gradients`
- propagate the new argument through `CircuitProbFunction` and `plot_circuit`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68426cf794fc8330aa047954a455fb53