### PR TITLE
Implement dataset-level PCA preprocessing

### DIFF
--- a/src/run.py
+++ b/src/run.py
@@ -70,11 +70,13 @@ def main() -> None:
             train_subset,
             batch_size=PRELOAD_BATCH_SIZE,
             desc="Preloading training subset features...",
+            pca_dim=FEATURES_PER_LAYER,
         )
         val_subset = preload_dataset(
             val_subset,
             batch_size=PRELOAD_BATCH_SIZE,
             desc="Preloading validation subset features...",
+            pca_dim=FEATURES_PER_LAYER,
         )
 
     test_indices = filter_indices_by_class(test_dataset, NUM_CLASSES)[:TEST_SUBSET_SIZE]
@@ -84,6 +86,7 @@ def main() -> None:
             test_subset,
             batch_size=PRELOAD_BATCH_SIZE,
             desc="Preloading test subset features...",
+            pca_dim=FEATURES_PER_LAYER,
         )
     test_loader = DataLoader(
         test_subset,

--- a/tests/test_preload_pca.py
+++ b/tests/test_preload_pca.py
@@ -1,0 +1,19 @@
+import sys
+import os
+import pytest
+
+torch = pytest.importorskip("torch")
+
+sys.path.append(os.path.join(os.path.dirname(__file__), "..", "src"))
+from data_utils import preload_dataset
+import config
+
+
+def test_preload_dataset_pca_reduces_dim():
+    data = torch.randn(10, config.ENCODING_DIM)
+    labels = torch.zeros(10, dtype=torch.long)
+    dataset = torch.utils.data.TensorDataset(data, labels)
+    ds = preload_dataset(dataset, batch_size=4, pca_dim=5)
+    x0, _ = ds[0]
+    assert x0.shape[0] == 5
+    assert len(ds) == 10


### PR DESCRIPTION
## Summary
- reduce feature dimensionality during preloading using PCA
- call PCA compression when preloading train/val/test splits
- add regression test for PCA compression

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6847e34739b483308bf14b4c73db986b