### PR TITLE
Use feature qubits for output

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,14 +58,16 @@ pytest
 Multi-layer or entangling quantum circuits are now differentiated using the
 parameter-shift rule.
 
-### Dedicated output qubits
+### Output qubit options
 
-Setting `config.NUM_OUTPUT_QUBITS` to a value greater than zero adds
-additional qubits that are measured for class prediction. Circuit
-simulation is still enabled automatically when entangling layers or
-multiple parameterized layers are used. When only a single non-entangling
-layer is present, class probabilities for the output qubits are computed
-analytically for improved performance.
-When using dedicated output qubits, the training labels are converted
-to probability vectors of length `2 ** NUM_OUTPUT_QUBITS` so that the
-loss computation matches the model output.
+When `config.USE_FEATURE_OUTPUT` is `True` and `NUM_OUTPUT_QUBITS` is `0`,
+the highest feature qubits are reused for class prediction. The number of
+bits required is determined from `config.NUM_CLASSES`.
+If `NUM_OUTPUT_QUBITS` is set to a positive value, dedicated qubits are
+allocated instead. Circuit simulation is still enabled automatically when
+entangling layers or multiple parameterized layers are used. When only a
+single non-entangling layer is present, class probabilities for the output
+qubits are computed analytically for improved performance.  In the dedicated
+case the training labels are converted to probability vectors of length
+`2 ** NUM_OUTPUT_QUBITS` so that the loss computation matches the model
+output.

--- a/README.md
+++ b/README.md
@@ -62,7 +62,8 @@ parameter-shift rule.
 
 When `config.USE_FEATURE_OUTPUT` is `True` and `NUM_OUTPUT_QUBITS` is `0`,
 the highest feature qubits are reused for class prediction. The number of
-bits required is determined from `config.NUM_CLASSES`.
+bits required is determined from `config.NUM_CLASSES`.  Ensure that the
+resulting value does not exceed `config.NUM_QUBITS`.
 If `NUM_OUTPUT_QUBITS` is set to a positive value, dedicated qubits are
 allocated instead. Circuit simulation is still enabled automatically when
 entangling layers or multiple parameterized layers are used. When only a

--- a/src/config.py
+++ b/src/config.py
@@ -29,7 +29,11 @@ DEVICE = torch.device("cuda" if torch.cuda.is_available() else "cpu")
 NUM_QUBITS = 10 # <24 number of feature-encoding qubits 
 # Optional dedicated output qubits.  When non-zero, ``NUM_QUBITS`` only
 # specifies the number of qubits used for encoding input features.
-NUM_OUTPUT_QUBITS = 2
+# When ``NUM_OUTPUT_QUBITS`` is zero, the highest feature qubits are measured
+# for class predictions.  Set to a positive value to allocate dedicated output
+# qubits instead.
+NUM_OUTPUT_QUBITS = 0
+USE_FEATURE_OUTPUT = True
 FEATURES_PER_LAYER = 12  # >NUM_QUBITS, <SUBSET_SIZE inputs consumed by adaptive_entangling_circuit
 NUM_LAYERS = 6  # number of parameterized layers in the quantum circuit
 NUM_CLASSES = 4

--- a/src/model.py
+++ b/src/model.py
@@ -220,6 +220,11 @@ class QuantumLLPModel(nn.Module):
         probs_batch = []
         for x in x_batch:
             if self.adaptive:
+                if x.shape[0] < self.features_per_layer:
+                    raise ValueError(
+                        f"QuantumLLPModel requires at least {self.features_per_layer}"
+                        f" features for adaptive encoding, got {x.shape[0]}"
+                    )
                 features = x[: self.features_per_layer]
             else:
                 if x.shape[0] != self.n_feature_qubits:

--- a/src/model.py
+++ b/src/model.py
@@ -221,12 +221,12 @@ class QuantumLLPModel(nn.Module):
         probs_batch = []
         for x in x_batch:
             if self.adaptive:
-                if x.shape[0] < self.features_per_layer:
-                    raise ValueError(
-                        f"QuantumLLPModel requires at least {self.features_per_layer}"
-                        f" features for adaptive encoding, got {x.shape[0]}"
-                    )
-                features = x[: self.features_per_layer]
+                features = x
+                features_per_layer = self.features_per_layer
+                if features.shape[0] < features_per_layer:
+                    features_per_layer = features.shape[0]
+                else:
+                    features = features[:features_per_layer]
             else:
                 if x.shape[0] != self.n_feature_qubits:
                     x = x[: self.n_feature_qubits]
@@ -256,7 +256,7 @@ class QuantumLLPModel(nn.Module):
                         qargs,
                         shots,
                         True,
-                        self.features_per_layer,
+                        features_per_layer,
                     )
                 else:
                     full_probs = CircuitProbFunction.apply(

--- a/src/run.py
+++ b/src/run.py
@@ -27,6 +27,7 @@ def main() -> None:
         VAL_SPLIT,
         NUM_QUBITS,
         NUM_OUTPUT_QUBITS,
+        USE_FEATURE_OUTPUT,
         FEATURES_PER_LAYER,
         NUM_LAYERS,
         RUN_EPOCHS,
@@ -112,6 +113,7 @@ def main() -> None:
         entangling=NUM_LAYERS > 1,
         n_output_qubits=NUM_OUTPUT_QUBITS,
         adaptive=True,
+        use_feature_output=USE_FEATURE_OUTPUT,
     ).to(DEVICE)
     train_model(
         model,


### PR DESCRIPTION
## Summary
- reuse highest feature qubits for class predictions when `USE_FEATURE_OUTPUT` is set
- update configuration and README to document the option
- fallback to CPU simulators if GPU support is unavailable
- allow selecting feature output qubits in `QuantumLLPModel`
- wire the option into the training script

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_684a435431548330b2c66c49335976df