### PR TITLE
Handle outputs via high bits

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,9 +62,10 @@ parameter-shift rule.
 
 Setting `config.NUM_OUTPUT_QUBITS` to a value greater than zero adds
 additional qubits that are measured for class prediction.  When the value
-is zero, the model instead groups the highest-order qubits of the feature
-register using `ceil(log2(NUM_CLASSES))` bits to obtain class
-probabilities, so no extra qubits are required.
+is zero, the model reuses the highest-order qubits of the feature register
+using `ceil(log2(NUM_CLASSES))` bits.  These qubits are passed as `qargs`
+to the circuit simulator so that the full state does not need to be
+measured.
 Circuit simulation is still enabled automatically when entangling layers or
 multiple parameterized layers are used. When only a single non-entangling
 layer is present, class probabilities for the output qubits are computed

--- a/README.md
+++ b/README.md
@@ -61,11 +61,14 @@ parameter-shift rule.
 ### Dedicated output qubits
 
 Setting `config.NUM_OUTPUT_QUBITS` to a value greater than zero adds
-additional qubits that are measured for class prediction. Circuit
-simulation is still enabled automatically when entangling layers or
+additional qubits that are measured for class prediction.  When the value
+is zero, the model instead groups the highest-order qubits of the feature
+register using `ceil(log2(NUM_CLASSES))` bits to obtain class
+probabilities, so no extra qubits are required.
+Circuit simulation is still enabled automatically when entangling layers or
 multiple parameterized layers are used. When only a single non-entangling
 layer is present, class probabilities for the output qubits are computed
-analytically for improved performance.
-When using dedicated output qubits, the training labels are converted
-to probability vectors of length `2 ** NUM_OUTPUT_QUBITS` so that the
-loss computation matches the model output.
+analytically for improved performance.  When using dedicated output qubits,
+the training labels are converted to probability vectors of length
+`2 ** NUM_OUTPUT_QUBITS` so that the loss computation matches the model
+output.


### PR DESCRIPTION
## Summary
- use highest qubits as outputs when `NUM_OUTPUT_QUBITS` is 0
- document the new behaviour in README

## Testing
- `pytest -q` *(fails: Simulation device "GPU" is not supported on this system)*

------
https://chatgpt.com/codex/tasks/task_b_684a63f969c083309e14e0eab322da26