### PR TITLE
Limit measured qubits for class output

### DIFF
--- a/src/quantum_utils.py
+++ b/src/quantum_utils.py
@@ -126,7 +126,8 @@ def circuit_state_probs(
         if circ.num_clbits < len(qargs):
             circ.add_register(ClassicalRegister(len(qargs) - circ.num_clbits))
         circ.measure(qargs, range(len(qargs)))
-        sim = AerSimulator(device='GPU')
+        dev = 'GPU' if torch.cuda.is_available() else 'CPU'
+        sim = AerSimulator(device=dev)
         circ = transpile(circ, backend=sim)
         result = sim.run(circ, shots=shots).result()
         counts = result.get_counts()

--- a/tests/test_feature_output_qubits.py
+++ b/tests/test_feature_output_qubits.py
@@ -1,0 +1,20 @@
+import sys
+import os
+import pytest
+
+torch = pytest.importorskip("torch")
+pytest.importorskip("qiskit")
+
+sys.path.append(os.path.join(os.path.dirname(__file__), "..", "src"))
+import config
+from model import QuantumLLPModel
+
+
+def test_circuit_feature_qargs_output_shape():
+    config.MEASURE_SHOTS = None
+    model = QuantumLLPModel(n_qubits=4, use_circuit=True)
+    x_batch = torch.rand(2, 4)
+    probs = model(x_batch)
+    assert probs.shape == (2, config.NUM_CLASSES)
+    sums = probs.sum(dim=1)
+    assert torch.allclose(sums, torch.ones_like(sums), atol=1e-6)


### PR DESCRIPTION
## Summary
- measure only the required feature qubits when no dedicated output qubits
- avoid Aer GPU requirement by falling back to CPU
- test circuit output dimension with feature qubit measurement

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_684a6675b6048330a14c4c58b2808071