### PR TITLE
Limit measurements to leading feature qubits

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -4,8 +4,8 @@ import os
 
 # Dataset settings
 DATA_ROOT = "./data"
-SUBSET_SIZE = 20
-TEST_SUBSET_SIZE = 20
+SUBSET_SIZE = 120
+TEST_SUBSET_SIZE = 30
 BAG_SIZE = 1  # number of samples per bag
 BATCH_SIZE = BAG_SIZE  # backward compatibility
 ENCODING_DIM = 384 #ViT-S/14アーキテクチャの埋め込みサイズは384
@@ -29,8 +29,8 @@ DEVICE = torch.device("cuda" if torch.cuda.is_available() else "cpu")
 NUM_QUBITS = 10 # <24 number of feature-encoding qubits 
 # Optional dedicated output qubits.  When non-zero, ``NUM_QUBITS`` only
 # specifies the number of qubits used for encoding input features.
-NUM_OUTPUT_QUBITS = 2
-FEATURES_PER_LAYER = 10  # >NUM_QUBITS, <SUBSET_SIZE inputs consumed by adaptive_entangling_circuit
+NUM_OUTPUT_QUBITS = 0
+FEATURES_PER_LAYER = 20  # >NUM_QUBITS, <SUBSET_SIZE*VAL_SPLIT inputs consumed by adaptive_entangling_circuit
 NUM_LAYERS = 6  # number of parameterized layers in the quantum circuit
 NUM_CLASSES = 4
 MEASURE_SHOTS = 100

--- a/src/model.py
+++ b/src/model.py
@@ -214,7 +214,19 @@ class QuantumLLPModel(nn.Module):
                 if self.n_output_qubits > 0:
                     qargs = list(range(self.n_feature_qubits, self.n_qubits))
                 else:
-                    qargs = None
+                    # NUM_CLASSES に応じて必要なビット数を計算
+                    n_bits = math.ceil(math.log2(NUM_CLASSES))
+
+                    # チェック: 特徴ビット数で表現可能か？
+                    if n_bits > self.n_feature_qubits:
+                        raise ValueError(
+                            f"NUM_CLASSES={NUM_CLASSES} を表現するには {n_bits} ビット必要ですが、"
+                            f"n_feature_qubits={self.n_feature_qubits} しかありません。"
+                        )
+
+                    # 特徴ビットの末尾 n_bits 個を出力ビットとして測定
+                    qargs = list(range(self.n_feature_qubits - n_bits, self.n_feature_qubits))
+                    
                 shots = getattr(config, "MEASURE_SHOTS", None)
                 if self.adaptive:
                     full_probs = CircuitProbFunction.apply(

--- a/tests/test_adaptive_forward.py
+++ b/tests/test_adaptive_forward.py
@@ -13,6 +13,7 @@ from model import QuantumLLPModel
 def test_forward_with_adaptive_encoding():
     config.MEASURE_SHOTS = None
     model = QuantumLLPModel(n_qubits=4, adaptive=True)
+    print(f"Qubits in circuit: {model.circuit.qubits}")  # Debugging line
     x_batch = torch.rand(2, config.FEATURES_PER_LAYER)
     probs = model(x_batch)
     assert probs.shape[0] == 2


### PR DESCRIPTION
## Summary
- compute classification probabilities from the highest feature qubits when no dedicated output qubits are present
- add `math` import for new calculations

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_684a8b52cd8c83308cad662e69878a4c