### PR TITLE
Add amplitude encoding option

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,3 +69,10 @@ analytically for improved performance.
 When using dedicated output qubits, the training labels are converted
 to probability vectors of length `2 ** NUM_OUTPUT_QUBITS` so that the
 loss computation matches the model output.
+
+### Amplitude encoding
+
+Setting `config.USE_AMPLITUDE_ENCODING = True` enables amplitude-based
+state preparation for input features. The feature vector is normalised and
+padded or truncated to the available qubits before being used to
+initialise the quantum state via `QuantumCircuit.initialize`.

--- a/src/config.py
+++ b/src/config.py
@@ -34,6 +34,7 @@ FEATURES_PER_LAYER = 20  # >NUM_QUBITS, <SUBSET_SIZE*VAL_SPLIT inputs consumed b
 NUM_LAYERS = 6  # number of parameterized layers in the quantum circuit
 NUM_CLASSES = 4
 MEASURE_SHOTS = 100
+USE_AMPLITUDE_ENCODING = False
 
 # Training settings
 DEFAULT_EPOCHS = 10

--- a/src/run.py
+++ b/src/run.py
@@ -42,6 +42,7 @@ def main() -> None:
         MODEL_FILE_NAME,
         START_MODEL_FILE_NAME,
         SAVE_MODEL_EPOCH_NUM,
+        USE_AMPLITUDE_ENCODING,
     )
 
     # Allow PyTorch to utilise multiple CPU cores for forward passes
@@ -115,7 +116,8 @@ def main() -> None:
         num_layers=NUM_LAYERS,
         entangling=NUM_LAYERS > 1,
         n_output_qubits=NUM_OUTPUT_QUBITS,
-        adaptive=True,
+        adaptive=not USE_AMPLITUDE_ENCODING,
+        amplitude_encoding=USE_AMPLITUDE_ENCODING,
     ).to(DEVICE)
 
     start_epoch = 0

--- a/tests/test_model_forward.py
+++ b/tests/test_model_forward.py
@@ -17,3 +17,13 @@ def test_forward_outputs_sum_to_one():
     assert probs.shape == (2, config.NUM_CLASSES)
     sums = probs.sum(dim=1)
     assert torch.allclose(sums, torch.ones_like(sums), atol=1e-6)
+
+
+def test_forward_amplitude_encoding():
+    config.MEASURE_SHOTS = None
+    model = QuantumLLPModel(n_qubits=2, amplitude_encoding=True)
+    x_batch = torch.rand(3, 4)
+    probs = model(x_batch)
+    assert probs.shape[0] == 3
+    sums = probs.sum(dim=1)
+    assert torch.allclose(sums, torch.ones_like(sums), atol=1e-6)

--- a/tests/test_quantum_utils.py
+++ b/tests/test_quantum_utils.py
@@ -11,6 +11,7 @@ from quantum_utils import (
     data_to_circuit,
     adaptive_entangling_circuit,
     circuit_state_probs,
+    amplitude_encoding,
 )
 import config
 from qiskit import QuantumCircuit
@@ -43,4 +44,11 @@ def test_circuit_state_probs_shots():
     probs = circuit_state_probs(qc, shots=200)
     assert probs.shape == (2,)
     assert abs(probs[0] - 0.5) < 0.2
+
+
+def test_amplitude_encoding_probs():
+    qc = amplitude_encoding([1.0, 0.0, 1.0, 0.0], n_qubits=2)
+    probs = circuit_state_probs(qc)
+    assert probs.shape == (4,)
+    assert torch.allclose(probs.sum(), torch.tensor(1.0))
 


### PR DESCRIPTION
## Summary
- implement amplitude_encoding and amplitude_data_to_circuit helpers
- support amplitude encoding in QuantumLLPModel and CircuitProbFunction
- make the new feature configurable via config and run script
- test amplitude encoding for circuits and model forward
- document amplitude encoding in the README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_685a366a9ac0833086f37c9946226e22