### PR TITLE
Remove stray QuantumCircuit import

### DIFF
--- a/src/model.py
+++ b/src/model.py
@@ -10,7 +10,6 @@ from quantum_utils import (
     amplitude_data_to_circuit,
     circuit_state_probs,
     parameter_shift_gradients,
-    QuantumCircuit,
 )
 
 


### PR DESCRIPTION
## Summary
- drop unused `QuantumCircuit` from `model.py`
- tests continue to pass

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_685cc6500de483309d8fdb41fb6e2e64