### PR TITLE
Add finite difference gradient option

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,8 +55,9 @@ docker run --rm --gpus all -v $(pwd):/app -w /app -it q-llp bash
 pytest
 ```
 
-Multi-layer or entangling quantum circuits are now differentiated using the
-parameter-shift rule.
+Multi-layer or entangling quantum circuits are differentiable using either
+the parameter-shift rule or a finite-difference approximation. The method can
+be selected via `config.GRADIENT_METHOD`.
 
 ### Dedicated output qubits
 

--- a/src/config.py
+++ b/src/config.py
@@ -36,6 +36,10 @@ NUM_CLASSES = 4
 MEASURE_SHOTS = 100
 USE_AMPLITUDE_ENCODING = False
 
+# Gradient computation method for multi-layer circuits.
+# Options: "parameter_shift" (default) or "finite_diff".
+GRADIENT_METHOD = "parameter_shift"
+
 # Training settings
 DEFAULT_EPOCHS = 10
 DEFAULT_LR = 0.01

--- a/src/run.py
+++ b/src/run.py
@@ -43,6 +43,7 @@ def main() -> None:
         START_MODEL_FILE_NAME,
         SAVE_MODEL_EPOCH_NUM,
         USE_AMPLITUDE_ENCODING,
+        GRADIENT_METHOD,
     )
 
     # Allow PyTorch to utilise multiple CPU cores for forward passes
@@ -118,6 +119,7 @@ def main() -> None:
         n_output_qubits=NUM_OUTPUT_QUBITS,
         adaptive=not USE_AMPLITUDE_ENCODING,
         amplitude_encoding=USE_AMPLITUDE_ENCODING,
+        gradient_method=GRADIENT_METHOD,
     ).to(DEVICE)
 
     start_epoch = 0

--- a/src/trainer.py
+++ b/src/trainer.py
@@ -4,6 +4,7 @@ import torch.optim as optim
 from torch.utils.data import DataLoader
 from tqdm import tqdm
 
+import config
 from config import (
     DEFAULT_EPOCHS,
     DEFAULT_LR,
@@ -34,6 +35,8 @@ def train_model(
 ):
     """Train model while recreating bags every epoch."""
     model.to(device)
+    if hasattr(model, "grad_method"):
+        model.grad_method = getattr(config, "GRADIENT_METHOD", model.grad_method)
     optimizer = optim.Adam(model.parameters(), lr=lr)
     loss_fn = nn.MSELoss()  # L2 loss between predicted and teacher class proportions
 

--- a/tests/test_gradient_methods.py
+++ b/tests/test_gradient_methods.py
@@ -1,0 +1,32 @@
+import sys
+import os
+import pytest
+np = pytest.importorskip("numpy")
+
+# Skip if PyTorch or qiskit are not installed
+torch = pytest.importorskip("torch")
+pytest.importorskip("qiskit")
+
+sys.path.append(os.path.join(os.path.dirname(__file__), "..", "src"))
+from quantum_utils import parameter_shift_gradients, finite_difference_gradients
+from model import QuantumLLPModel
+
+
+def test_finite_diff_matches_parameter_shift():
+    n_qubits = 2
+    x = torch.rand(n_qubits)
+    params = torch.randn(n_qubits)
+    ps_probs, ps_grads = parameter_shift_gradients(np.pi * x, params)
+    fd_probs, fd_grads = finite_difference_gradients(np.pi * x, params)
+    assert torch.allclose(ps_probs, fd_probs, atol=1e-6)
+    assert torch.allclose(ps_grads, fd_grads, atol=1e-2)
+
+
+def test_backward_with_finite_diff():
+    model = QuantumLLPModel(n_qubits=2, num_layers=2, entangling=True, gradient_method="finite_diff")
+    x_batch = torch.rand(3, 2)
+    pred = model(x_batch)
+    loss = pred.mean()
+    loss.backward()
+    assert model.params.grad is not None
+    assert model.params.grad.shape == (2, 2)


### PR DESCRIPTION
## Summary
- support choosing gradient estimator in config
- implement finite-difference gradients
- pass gradient method through model, trainer and run scripts
- test finite-difference gradient accuracy
- document gradient method option

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_685cdd0b67cc8330946237696c0972fe