### PR TITLE
Fix grayscale MNIST preprocessing

### DIFF
--- a/src/data_utils.py
+++ b/src/data_utils.py
@@ -107,6 +107,9 @@ class DinoEncoder:
         self.preprocess = _tt.Compose(
             [
                 _tt.Lambda(_maybe_to_tensor),
+                _tt.Lambda(
+                    lambda x: x.expand(3, -1, -1) if x.dim() == 3 and x.shape[0] == 1 else x
+                ),
                 _tt.Resize(224, antialias=True),
                 _tt.CenterCrop(224),
                 _tt.Normalize(mean=(0.485, 0.456, 0.406), std=(0.229, 0.224, 0.225)),

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -27,6 +27,14 @@ def test_transform_output_size():
     assert out.shape[0] == config.ENCODING_DIM
 
 
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="Requires CUDA for DINOv2/xFormers attention")
+def test_transform_grayscale():
+    transform = get_transform()
+    x = torch.randn(1, 28, 28)
+    out = transform(x)
+    assert out.shape[0] == config.ENCODING_DIM
+
+
 def test_compute_proportions():
     labels = torch.tensor([0, 1, 1, 2, 3, 3])
     props = compute_proportions(labels, 4)


### PR DESCRIPTION
## Summary
- handle single-channel images in DINO preprocessing
- add unit test for grayscale transform

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_685e292a93ec8330a824f7fa36b1f1c8