### PR TITLE
Add optional saving of dataset features

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ Quantum Learning from Label Proportion
 GPU 利用時にワーカーを有効にするため、スクリプト冒頭で
 `torch.multiprocessing.set_start_method("spawn")` を呼び出しています。
 特徴量を事前計算してメモリに展開するには `config.PRELOAD_DATASET` を `True` に設定します。
+PCA 圧縮前後の特徴量を保存したい場合は `config.PRELOAD_SAVE_BEFORE` および
+`config.PRELOAD_SAVE_AFTER` にファイルパスを指定してください。
 
 学習済みモデルから量子回路図を描画するには `plot_circuit.py` を使用します。(configはrun.py実行時と同じに)
 以下のように実行すると `circuit.png` に図が保存されます。

--- a/src/config.py
+++ b/src/config.py
@@ -21,6 +21,8 @@ PIN_MEMORY = torch.cuda.is_available()
 # Dataset preloading settings
 PRELOAD_DATASET = True
 PRELOAD_BATCH_SIZE = 512
+PRELOAD_SAVE_BEFORE = ""
+PRELOAD_SAVE_AFTER = ""
 
 # Device configuration
 DEVICE = torch.device("cuda" if torch.cuda.is_available() else "cpu")

--- a/src/run.py
+++ b/src/run.py
@@ -39,6 +39,8 @@ def main() -> None:
         PIN_MEMORY,
         PRELOAD_DATASET,
         PRELOAD_BATCH_SIZE,
+        PRELOAD_SAVE_BEFORE,
+        PRELOAD_SAVE_AFTER,
         MODEL_FILE_NAME,
         START_MODEL_FILE_NAME,
         SAVE_MODEL_EPOCH_NUM,
@@ -81,12 +83,16 @@ def main() -> None:
             batch_size=PRELOAD_BATCH_SIZE,
             desc="Preloading training subset features...",
             pca_dim=FEATURES_PER_LAYER,
+            save_before=PRELOAD_SAVE_BEFORE,
+            save_after=PRELOAD_SAVE_AFTER,
         )
         val_subset = preload_dataset(
             val_subset,
             batch_size=PRELOAD_BATCH_SIZE,
             desc="Preloading validation subset features...",
             pca_dim=FEATURES_PER_LAYER,
+            save_before=PRELOAD_SAVE_BEFORE,
+            save_after=PRELOAD_SAVE_AFTER,
         )
 
     test_indices = filter_indices_by_class(test_dataset, NUM_CLASSES)[:TEST_SUBSET_SIZE]
@@ -97,6 +103,8 @@ def main() -> None:
             batch_size=PRELOAD_BATCH_SIZE,
             desc="Preloading test subset features...",
             pca_dim=FEATURES_PER_LAYER,
+            save_before=PRELOAD_SAVE_BEFORE,
+            save_after=PRELOAD_SAVE_AFTER,
         )
     test_loader = DataLoader(
         test_subset,

--- a/tests/test_preload_pca.py
+++ b/tests/test_preload_pca.py
@@ -17,3 +17,23 @@ def test_preload_dataset_pca_reduces_dim():
     x0, _ = ds[0]
     assert x0.shape[0] == 5
     assert len(ds) == 10
+
+
+def test_preload_dataset_saves_features(tmp_path):
+    data = torch.randn(4, config.ENCODING_DIM)
+    labels = torch.arange(4)
+    dataset = torch.utils.data.TensorDataset(data, labels)
+    before = tmp_path / "before.pt"
+    after = tmp_path / "after.pt"
+    _ = preload_dataset(
+        dataset,
+        batch_size=2,
+        pca_dim=2,
+        save_before=str(before),
+        save_after=str(after),
+    )
+    before_data = torch.load(before)
+    after_data = torch.load(after)
+    assert torch.equal(before_data["features"], data)
+    assert torch.equal(before_data["labels"], labels)
+    assert after_data["features"].shape[1] == 2


### PR DESCRIPTION
## Summary
- allow saving dataset features before/after PCA via `preload_dataset`
- expose paths in config and wire through `run.py`
- document new config options
- test saving functionality

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_685e348942208330b8133d8975bc3d3f