### PR TITLE
Fix VQC LLP example

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Quantum Learning from Label Proportion
    ```
 2. 依存パッケージをインストールします。
    ```bash
-   pip install torch torchvision qiskit pytest
+   pip install torch torchvision qiskit qiskit-machine-learning pytest
    ```
 3. 学習を実行します。
    ```bash


### PR DESCRIPTION
## Summary
- fix the VQC LLP example to use TorchConnector
- note qiskit-machine-learning installation in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_686215d2d2dc8330920bb0bb20a5dd9c