### PR TITLE
Fix VQC sample classification output

### DIFF
--- a/src/vqc_llp_example.py
+++ b/src/vqc_llp_example.py
@@ -21,7 +21,8 @@ LR = 0.1
 feature_map = ZZFeatureMap(feature_dimension=NUM_QUBITS)
 ansatz = TwoLocal(NUM_QUBITS, ['ry', 'rz'], 'cx', reps=NUM_LAYERS)
 
-vqc = VQC(feature_map=feature_map, ansatz=ansatz, optimizer=None)
+vqc = VQC(feature_map=feature_map, ansatz=ansatz,
+          optimizer=None, num_classes=NUM_CLASSES)
 nn = getattr(vqc, "neural_network", None)
 if nn is None:
     nn = getattr(vqc, "_neural_network")


### PR DESCRIPTION
## Summary
- update `src/vqc_llp_example.py` to set `num_classes` for VQC so teacher and predictions match

## Testing
- `python -m py_compile src/vqc_llp_example.py`
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6862185e9a68833098a8e3acbc25c9e1