### PR TITLE
Handle DINO features with PCA

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,14 +99,16 @@ CUDA が利用可能な環境では自動的に GPU を使用して計算しま�
 #### DINO 特徴量と振幅エンコーディングを使用する
 
 `vqc_llp_example.py` では以下のフラグを指定することで DINO 特徴量の利用や
-PCA 圧縮、振幅エンコーディングを試すことができます。
+振幅エンコーディングを試すことができます。DINO 特徴量を使用する際は
+自動的に PCA による次元削減が行われます。
 
 ```bash
-python src/vqc_llp_example.py --use-dino --preload --amplitude
+python src/vqc_llp_example.py --use-dino --amplitude
 ```
 
-`--use-dino` は `get_transform(use_dino=True)` を、`--preload` は
-`preload_dataset(..., pca_dim=NUM_QUBITS)` を適用します。
+`--use-dino` は `get_transform(use_dino=True)` を適用し、内部で
+`preload_dataset(..., pca_dim=NUM_QUBITS)` を使って特徴量を `NUM_QUBITS`
+次元に圧縮します。
 `--amplitude` を指定すると各サンプルを `quantum_utils.amplitude_encoding`
 で量子状態に変換してから学習を行います。
 `--feature-map` には `zz` や `pauli` のほか `adaptive`、`npqc`、`yzcx`、`amplitude`

--- a/src/vqc_llp_example.py
+++ b/src/vqc_llp_example.py
@@ -111,9 +111,20 @@ def main():
     val_indices = [i for i, t in enumerate(val_dataset.targets) if t < NUM_CLASSES][:TEST_SUBSET_SIZE]
     val_subset = Subset(val_dataset, val_indices)
 
-    if args.preload:
-        train_subset = preload_dataset(train_subset, batch_size=BAG_SIZE, pca_dim=NUM_QUBITS)
-        val_subset = preload_dataset(val_subset, batch_size=BAG_SIZE, pca_dim=NUM_QUBITS)
+    if args.preload or args.use_dino:
+        # When using DINO features the raw dimensionality (ENCODING_DIM)
+        # does not match ``NUM_QUBITS`` required by the feature map.
+        # Reduce all features via PCA so VQC receives ``NUM_QUBITS`` inputs.
+        train_subset = preload_dataset(
+            train_subset,
+            batch_size=BAG_SIZE,
+            pca_dim=NUM_QUBITS,
+        )
+        val_subset = preload_dataset(
+            val_subset,
+            batch_size=BAG_SIZE,
+            pca_dim=NUM_QUBITS,
+        )
 
     train_loader = DataLoader(train_subset, batch_size=BAG_SIZE, shuffle=True)
     val_loader = DataLoader(val_subset, batch_size=BAG_SIZE)


### PR DESCRIPTION
## Summary
- automatically run PCA when using DINO features so the data size matches the qubit count
- update README example

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_686cc260355483308c201f576966738d